### PR TITLE
[JO][73229910]  Image slider/photo carousel not working for browser sizes other than hundred percent zoom level

### DIFF
--- a/src/ui/carousel.coffee
+++ b/src/ui/carousel.coffee
@@ -59,8 +59,8 @@ define [
       scrollable.smoothDivScroll({
         autoScrollingMode: "always",
         autoScrollingDirection: "endlessloopright",
-        autoScrollingStep: 1,
-        autoScrollingInterval: 15
+        autoScrollingStep: 3,
+        autoScrollingInterval: 20
       })
 
       scrollable.smoothDivScroll("recalculateScrollableArea")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/73229910
- In conjunction with the rentals story for the carousel issue, this addresses the resizing of the browser window.
