### PR TITLE
[MTS/LF] [73209846] Scope component definition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "carousel",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "main": "carousel.js",
   "dependencies": {
     "flight"                    : ">=1.0.4 < 1.1.0",

--- a/data/carousel.js
+++ b/data/carousel.js
@@ -16,7 +16,11 @@
         return this.on('uiCarouselRequested', this.serveCarouselRequested);
       });
     };
-    return defineComponent(carousel);
+    return {
+      defineComponent: function() {
+        return defineComponent(carousel);
+      }
+    };
   });
 
 }).call(this);

--- a/src/data/carousel.coffee
+++ b/src/data/carousel.coffee
@@ -20,4 +20,4 @@ define [
     @after 'initialize', ->
       @on 'uiCarouselRequested', @serveCarouselRequested
 
-  defineComponent carousel
+  defineComponent: -> defineComponent(carousel)


### PR DESCRIPTION
We were running into problems with the carousel's flight dependency.
Flight.js was invoking Object.keys, which didn't exist in older browsers
we wanted to support. We wanted to stall defining the component until
the client code could use some shims to monkey patch Object.
